### PR TITLE
Update auto-mock behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.11 Auto mock tweaks
+
+- `auto` mocks patch requests even if network mode is enabled.
+- `preferNetwork` boolean is added to allow network first responses even if
+  an auto-mock is available.
+
 ## 0.0.10 Better image handling, auto mocking
 
 - Let users specify a filepath during an auto-mock. This filepath will be read

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ module.exports = {
     '**/*.png': 204,
     // It's possible to respond with placeholder images instead of blank/broken 204s
     // Note that you must spcify a filepath, not file contents
-    '**/*.jpg': { status: 200, file: 'placeholder.jpg' },
+    '**/*.jpg': { status: 200, file: 'placeholder.jpg', preferNetwork: true },
     '**/*.ico': 204,
     '**/log': { status: 200, statusMessage: 'auto mock log' },
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jambox",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Tool for recording and playing back HTTP requests.",
   "bin": {
     "jam": "./jam.mjs",

--- a/src/__tests__/server.test.mjs
+++ b/src/__tests__/server.test.mjs
@@ -146,6 +146,7 @@ test.serial('auto mocks', async (t) => {
     .send({
       auto: {
         '**/path.html': { status: 204 },
+        '**/*.jpg': { status: 204, preferNetwork: true },
       },
     })
     .expect(200);

--- a/src/__tests__/server.test.mjs
+++ b/src/__tests__/server.test.mjs
@@ -137,6 +137,38 @@ test.serial('ws - request inspect', async (t) => {
   await plan;
 });
 
+test.serial('auto mocks', async (t) => {
+  t.assert(t.context.server, `Server init error: ${t.context.error?.stack}`);
+  const { body: config } = await supertest(t.context.server).get('/api/config');
+
+  await supertest(t.context.server)
+    .post('/api/config')
+    .send({
+      auto: {
+        '**/path.html': { status: 204 },
+      },
+    })
+    .expect(200);
+
+  const plan = superwstest(config.serverURL)
+    .ws('/')
+    .expectJson((json) => {
+      t.like(json, {
+        type: 'request',
+        payload: { url: 'http://random-domain.com/path.html' },
+      });
+    })
+    .expectJson((json) => {
+      t.like(json, { type: 'response', payload: { statusCode: 204 } });
+    });
+
+  const opts = { agent: new HttpsProxyAgent(config.proxy.http) };
+
+  await fetch('http://random-domain.com/path.html', opts).catch(console.log);
+
+  await plan;
+});
+
 // NOTE: This does work but needs a better cache mock
 test('server - reset', async (t) => {
   t.assert(t.context.server, `Server init error: ${t.context.error?.stack}`);

--- a/src/server/handlers.mjs
+++ b/src/server/handlers.mjs
@@ -183,10 +183,7 @@ export const auto = (svc, config) => {
   return Promise.all(
     Object.entries(config.value.auto).map(([path, value]) => {
       const options = typeof value === 'object' ? value : { status: value };
-      if (
-        options.preferNetwork &&
-        config.value.blockNetworkRequests === false
-      ) {
+      if (options.preferNetwork && !config.value.blockNetworkRequests) {
         return;
       }
       return svc.proxy.addRequestRule({

--- a/src/server/handlers.mjs
+++ b/src/server/handlers.mjs
@@ -181,9 +181,16 @@ export const forward = (svc, config) => {
 
 export const auto = (svc, config) => {
   return Promise.all(
-    Object.entries(config.value.auto).map(async ([path, value]) => {
+    Object.entries(config.value.auto).map(([path, value]) => {
       const options = typeof value === 'object' ? value : { status: value };
-      await svc.proxy.addRequestRule({
+      if (
+        options.preferNetwork &&
+        config.value.blockNetworkRequests === false
+      ) {
+        return;
+      }
+      return svc.proxy.addRequestRule({
+        priority: 99,
         matchers: [new GlobMatcher('*', { paths: [path] })],
         handler: new mockttp.requestHandlers.SimpleHandler(
           options.status,


### PR DESCRIPTION
- `auto` mocks patch requests even if network mode is enabled.
- `preferNetwork` boolean is added to allow network first responses even if
  an auto-mock is available.