### PR TITLE
Allow body stubs, fix re-rendering issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.23 - Fix re-renders
+
+- fix: unnecessary re-renders
+- feat: stop rendering waterfall after document loads
+- feat: clearing waterfall continues rendering incoming requests
+
 ## 0.0.22 - Implement cached response update flow
 
 - feat: users may now edit the cached responses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - fix: unnecessary re-renders
 - feat: stop rendering waterfall after document loads
 - feat: clearing waterfall continues rendering incoming requests
+- breaking change: rename `auto` option to `stub`
+- feat: let stubs define a `body` directly
 
 ## 0.0.22 - Implement cached response update flow
 

--- a/README.md
+++ b/README.md
@@ -112,13 +112,13 @@ module.exports = {
       websocket: true,
     },
   },
-  auto: {
+  stub: {
     '**/*.png': 204,
     // It's possible to respond with placeholder images instead of blank/broken 204s
     // Note that you must spcify a filepath, not file contents
     '**/*.jpg': { status: 200, file: 'placeholder.jpg', preferNetwork: true },
     '**/*.ico': 204,
-    '**/log': { status: 200, statusMessage: 'auto mock log' },
+    '**/log': { status: 200, statusMessage: 'stub log' },
   },
   cache: {
     write: 'auto',

--- a/ext/App.cy.js
+++ b/ext/App.cy.js
@@ -11,6 +11,13 @@ before(async () => {
         paths: ['**'],
       },
     },
+    stub: {
+      '**/pathC': {
+        status: 200,
+        statusMessage: 'OK',
+        body: { data: 'test-stub' },
+      },
+    },
     cache: {
       dir: '.jambox',
       write: 'auto',
@@ -24,6 +31,7 @@ describe('Web Extension', () => {
   it('can display seen requests', () => {
     // Jambox should generate a static hash for the URL below
     const HASH = '2be35430d93be811753ecfd6ba828878';
+    const STUB_HASH = 'cd4482b36a608021cd943786ecb54c5d';
     const testURL = 'http://jambox-test.com/returnThisAsJson';
     cy.mount(App, { props: { api } });
 
@@ -77,6 +85,11 @@ describe('Web Extension', () => {
     cy.get('@test-edit').click();
     cy.get('[data-cy-id="cache-delete"]').click();
     cy.get('[data-cy-id="cache-detail"]').should('not.exist');
+
+    cy.get(`[data-cy-id="cache-cell-edit-${STUB_HASH}"]`).as('stub');
+    cy.get('@stub').click();
+    cy.get('[data-cy-id="select-response-tab"]').click();
+    cy.get('[data-cy-id="cache-detail"]').contains('test-stub');
 
     cy.get('@test-edit')
       .should('not.exist')

--- a/ext/App.svelte
+++ b/ext/App.svelte
@@ -81,20 +81,15 @@
         />
       </div>
       <Route path="/">
-        <Waterfall data={$store} {history} />
+        <Waterfall {history} />
       </Route>
       <Route path="/cache">
-        <Cache cache={$store.cache} />
+        <Cache />
       </Route>
       <Route path="/cache/entry/:id" let:params>
-        <CacheEntry cacheEntry={$store.cache[params.id]} {api} {history} />
+        <CacheEntry id={params.id} {api} {history} />
       </Route>
-      <Route path="/request/:id" let:params>
-        <RequestInfo
-          response={$store.http[params.id].response}
-          request={$store.http[params.id].request}
-        />
-      </Route>
+      <Route path="/request/:id" component={RequestInfo} />
     </div>
   </Router>
 </main>

--- a/ext/App.svelte
+++ b/ext/App.svelte
@@ -34,6 +34,12 @@
     }
   });
 
+  chrome.webNavigation?.onCompleted.addListener((details) => {
+    if (details.tabId === chrome.devtools.inspectedWindow.tabId) {
+      store.update((state) => reducer(state, { type: 'complete' }));
+    }
+  });
+
   $: {
     cleanup?.();
     pauseChecked = $store.config.pause;

--- a/ext/Cache/index.svelte
+++ b/ext/Cache/index.svelte
@@ -3,12 +3,12 @@
   import SvelteTable from 'svelte-table';
   import Cell from './Cell.svelte';
 
-  export let cache;
+  // export let cache;
 
   let search = $store.filters.cache;
-  let data;
+  let data = [];
   $: {
-    data = Object.values(cache).filter(({ response }) => {
+    data = Object.values($store.cache).filter(({ response }) => {
       return typeof search === 'string' && search.length
         ? JSON.stringify(response.body || '').includes(search)
         : true;

--- a/ext/CacheEntry.svelte
+++ b/ext/CacheEntry.svelte
@@ -2,14 +2,17 @@
   import { without } from './nodash';
   import { JSONEditor } from 'svelte-jsoneditor';
   import { Link } from 'svelte-routing';
+  import { store } from './store';
 
   export let api;
   export let history;
-  export let cacheEntry;
+  export let id;
   let changes = null;
   let currentTab = 'details';
 
+  const cacheEntry = $store.cache[id];
   let response, request, details;
+
   $: {
     response = cacheEntry.response;
     request = cacheEntry.request;

--- a/ext/RequestInfo/index.svelte
+++ b/ext/RequestInfo/index.svelte
@@ -2,9 +2,12 @@
   import Headers from './Headers.svelte';
   import { Link } from 'svelte-routing';
   import { JSONEditor } from 'svelte-jsoneditor';
+  import { store } from '../store.js';
 
-  export let request;
-  export let response;
+  export let id;
+
+  const response = $store.http[id].response;
+  const request = $store.http[id].request;
 
   let currentTab = 'headers';
 </script>

--- a/ext/Waterfall.svelte
+++ b/ext/Waterfall.svelte
@@ -5,7 +5,6 @@
   import Checkbox from './Checkbox.svelte';
 
   export let history;
-  export let data;
 
   const chrome = window.chrome;
 
@@ -40,7 +39,7 @@
   }
 
   $: {
-    rows = Object.values(data.http).filter(({ contentType }) => {
+    rows = Object.values($store.http).filter(({ contentType }) => {
       return checked.includes(contentType);
     });
 

--- a/ext/Waterfall.svelte
+++ b/ext/Waterfall.svelte
@@ -108,6 +108,10 @@
   {/each}
 </div>
 
+<i
+  >Requests only shown until document and it's resources finish loading. Clear
+  waterfall to view network requests after document finished loading.</i
+>
 <div class="Content" use:watchResize={handleContentResize}>
   <svg
     {width}

--- a/ext/store.js
+++ b/ext/store.js
@@ -18,6 +18,7 @@ const getContentType = (url, response) => {
 };
 
 export const initialState = {
+  complete: false,
   config: {},
   http: {},
   abortedRequestById: {},
@@ -46,6 +47,7 @@ export const reducer = (state, action) => {
     case 'clear': {
       return {
         ...state,
+        complete: false,
         http: {},
       };
     }
@@ -58,10 +60,18 @@ export const reducer = (state, action) => {
     case 'refresh': {
       return {
         ...state,
+        complete: false,
         http: {},
       };
     }
+    case 'complete': {
+      return {
+        ...state,
+        complete: true,
+      };
+    }
     case 'abort': {
+      if (state.complete) return state;
       return {
         ...state,
         http: {
@@ -74,6 +84,7 @@ export const reducer = (state, action) => {
       };
     }
     case 'request': {
+      if (state.complete) return state;
       const url = new URL(payload.url);
       return {
         ...state,
@@ -88,6 +99,7 @@ export const reducer = (state, action) => {
       };
     }
     case 'response': {
+      if (state.complete) return state;
       // Extension refresh in the middle of a request -> response cycle
       if (!state.http[payload.id]) {
         return state;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jambox",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "description": "Tool for recording and playing back HTTP requests.",
   "bin": {
     "jam": "./jam.mjs",

--- a/recipes/nextjs-graphql-example/jambox.config.js
+++ b/recipes/nextjs-graphql-example/jambox.config.js
@@ -10,7 +10,7 @@ module.exports = {
       websocket: true,
     },
   },
-  auto: {
+  stub: {
     '**/*.jpg': { status: 200, file: path.join(__dirname, '200x200.jpg') },
   },
   cache: {

--- a/src/__tests__/server.test.mjs
+++ b/src/__tests__/server.test.mjs
@@ -144,7 +144,7 @@ test.serial('auto mocks', async (t) => {
   await supertest(t.context.server)
     .post('/api/config')
     .send({
-      auto: {
+      stub: {
         '**/path.html': { status: 204 },
         '**/*.jpg': { status: 204, preferNetwork: true },
       },
@@ -228,7 +228,7 @@ test.serial('pause', async (t) => {
   await supertest(t.context.server)
     .post('/api/config')
     .send({
-      auto: {
+      stub: {
         '**/**/*.jpg': { status: 204 },
       },
     })
@@ -240,7 +240,7 @@ test.serial('pause', async (t) => {
   // Baseline, get's a 204 auto-mock response
   let res = await doRequest();
   t.is(res.status, 204);
-  t.is(res.statusText, 'jambox auto-mock');
+  t.is(res.statusText, 'jambox stub');
 
   await supertest(t.context.server)
     .post('/api/pause')
@@ -260,7 +260,7 @@ test.serial('pause', async (t) => {
   // Unpaused, back to baseline
   res = await doRequest();
   t.is(res.status, 204);
-  t.is(res.statusText, 'jambox auto-mock');
+  t.is(res.statusText, 'jambox stub');
 });
 
 // NOTE: This does work but needs a better cache mock

--- a/src/server/__tests__/handlers.test.mjs
+++ b/src/server/__tests__/handlers.test.mjs
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { forward, record, auto } from '../handlers.mjs';
+import { forward, record, stub } from '../handlers.mjs';
 
 test.beforeEach((t) => {
   const rules = [];
@@ -79,23 +79,23 @@ test('cache', async (t) => {
   ]);
 });
 
-test('auto', async (t) => {
+test('stub', async (t) => {
   const config = {
     value: {
       // NOTE: Might be better to invert this setting
-      auto: {
+      stub: {
         '**.jpg': 204,
         '**/api': { status: 200 },
       },
     },
   };
 
-  await auto({ proxy: t.context.proxy }, config);
+  await stub({ proxy: t.context.proxy }, config);
 
   t.deepEqual(t.context.explainRules(), [
     'GlobMatcher {"target":"*","paths":["**.jpg"]}',
-    'respond with status 204 (jambox auto-mock)',
+    'respond with status 204 (jambox stub)',
     'GlobMatcher {"target":"*","paths":["**/api"]}',
-    'respond with status 200 (jambox auto-mock)',
+    'respond with status 200 (jambox stub)',
   ]);
 });

--- a/src/server/handlers.mjs
+++ b/src/server/handlers.mjs
@@ -190,9 +190,10 @@ export const stub = (svc, config) => {
       let response = null;
       if (options.file) {
         response = fs.readFileSync(options.file);
-      } else if (options.body) {
-        response = options.body;
+      } else if (options.body && typeof options.body === 'object') {
+        response = Buffer.from(JSON.stringify(options.body));
       }
+
       return svc.proxy.addRequestRule({
         priority: 99,
         matchers: [new GlobMatcher('*', { paths: [path] })],
@@ -319,7 +320,7 @@ export default async function handlers(svc, config) {
     await forward(svc, config);
   }
 
-  if (config.value.auto) {
+  if (config.value.stub) {
     await stub(svc, config);
   }
 }


### PR DESCRIPTION
```
- fix: unnecessary re-renders
- feat: stop rendering waterfall after document loads
- feat: clearing waterfall continues rendering incoming requests
- breaking change: rename `auto` option to `stub`
- feat: let stubs define a `body` directly
```