### PR TITLE
Bugfix: unhandled json parse errors during reset.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.24 - Fix broken cache file reads
+
+- fix: catch unhandled json parse during reset
+
 ## 0.0.23 - Fix re-renders
 
 - fix: unnecessary re-renders

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jambox",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "description": "Tool for recording and playing back HTTP requests.",
   "bin": {
     "jam": "./jam.mjs",

--- a/src/cache.mjs
+++ b/src/cache.mjs
@@ -234,18 +234,24 @@ class Cache {
       const { ext, name } = path.parse(filename);
 
       if (ext === '.json') {
+        const fullPath = path.join(dir, filename);
         debug(`read ${filename}`);
-        const json = JSON.parse(
-          fs.readFileSync(path.join(dir, filename), 'utf-8')
-        );
-        const obj = deserialize(json);
+        try {
+          const json = JSON.parse(fs.readFileSync(fullPath, 'utf-8'));
+          const obj = deserialize(json);
 
-        this.add(obj.request);
-        await this.commit(obj.response);
-        this.#cache[name].filename = filename;
-        this.#cache[name].dir = dir;
+          this.add(obj.request);
+          await this.commit(obj.response);
+          this.#cache[name].filename = filename;
+          this.#cache[name].dir = dir;
 
-        results[name] = obj;
+          results[name] = obj;
+        } catch (e) {
+          debug(
+            `failed to read ${filename}. The file will be deleted! ERROR: ${e}`
+          );
+          await unlink(fullPath);
+        }
       }
     }
 


### PR DESCRIPTION
Prevent `reset` from crashing if a read cache file is malformed.