### PR TITLE
fix: persited record update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.27 - Fix cache update bug
+
+- fix: updating a single persited record removes all other records
+
 ## 0.0.26 - Introduce zip archives as tapes
 
 - feature: introduce tapes as `.jambox/*.tape.zip` files

--- a/ext/Cache.cy.js
+++ b/ext/Cache.cy.js
@@ -50,21 +50,25 @@ describe('Cache UI', () => {
     cy.get('[data-cy-id="cache-detail"]').should('not.exist');
   });
 
-  it('can persist records and delete them after', () => {
+  it.only('can persist records and delete them after', () => {
     // load jambox config from cwd
     cy.task('jambox.reset');
     cy.mount(App, { props: { api } });
 
+    cy.request('http://jambox-test.com/pathA');
     cy.request('http://jambox-test.com/pathB');
     cy.request('http://jambox-test.com/pathC');
 
     cy.get('[data-cy-id="cache-link"]').click();
+    cy.get(`[data-cy-id="cache-cell-edit-${A}"]`).as('test-persist-A');
     cy.get(`[data-cy-id="cache-cell-edit-${B}"]`).as('test-persist');
     cy.get(`[data-cy-id="select-row-${B}"]`).as('test-persist-select');
+    cy.get(`[data-cy-id="select-row-${A}"]`).as('test-persist-select-A');
     cy.get(`[data-cy-id="cache-cell-edit-${C}"]`).as('test-in-memory-cache');
 
     // Persist should be click-able
     cy.get('@test-persist-select').click();
+    cy.get('@test-persist-select-A').click();
     cy.get('[data-cy-id="cache-persist"]').click();
     cy.get(`[data-cy-id="cache-cell-persisted-true-${B}"]`).should('exist');
 
@@ -104,8 +108,10 @@ describe('Cache UI', () => {
     cy.get('@test-in-memory-cache').should('not.exist');
 
     cy.get('@test-persist-select').click();
+    cy.get('@test-persist-select-A').click();
     cy.get('[data-cy-id="cache-delete"]').click();
 
     cy.get('@test-persist').should('not.exist');
+    cy.get('@test-persist-A').should('not.exist');
   });
 });

--- a/ext/Cache.cy.js
+++ b/ext/Cache.cy.js
@@ -50,7 +50,7 @@ describe('Cache UI', () => {
     cy.get('[data-cy-id="cache-detail"]').should('not.exist');
   });
 
-  it.only('can persist records and delete them after', () => {
+  it('can persist records and delete them after', () => {
     // load jambox config from cwd
     cy.task('jambox.reset');
     cy.mount(App, { props: { api } });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jambox",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "description": "Tool for recording and playing back HTTP requests.",
   "bin": {
     "jam": "./jam.mjs",

--- a/src/cache.mjs
+++ b/src/cache.mjs
@@ -212,7 +212,13 @@ class Cache {
    * @param ids {Array<string>}
    */
   async persist(ids) {
-    const zipfs = new ZipFS(this.tape, { create: true });
+    let create = false;
+    try {
+      await access(this.tape);
+    } catch (e) {
+      create = true;
+    }
+    const zipfs = new ZipFS(this.tape, { create });
 
     for (const hash of ids) {
       const record = this.#cache[hash];


### PR DESCRIPTION
The `create: true` was casing cache to always be rewritten during a persist.