### PR TITLE
Minor bugfixes

### DIFF
--- a/src/Config.mjs
+++ b/src/Config.mjs
@@ -22,12 +22,14 @@ const debug = createDebug('config');
  * @property {boolean=}       blockNetworkRequests
  * @property {boolean=}       paused
  * @property {string=}        port
+ * @property {string=}        browser
  */
 export default class Config extends Emitter {
   /**
    * @member {URL}
    */
   serverURL;
+  browser = 'chrome';
   cwd = '';
   dir = '';
   filepath = '';
@@ -124,6 +126,10 @@ export default class Config extends Emitter {
       this.serverURL.port = options.port;
     }
 
+    if (typeof options.browser === 'string') {
+      this.browser = options.browser;
+    }
+
     this.dispatch('update', this.serialize());
   }
 
@@ -184,6 +190,7 @@ export default class Config extends Emitter {
 
   serialize() {
     return {
+      browser: this.browser,
       serverURL: this.serverURL.origin,
       paused: this.paused,
       blockNetworkRequests: this.blockNetworkRequests,

--- a/src/__tests__/server.test.mjs
+++ b/src/__tests__/server.test.mjs
@@ -43,6 +43,7 @@ test.serial('ws - config', async (t) => {
   await supertest(t.context.server)
     .post('/api/config')
     .send({
+      browser: 'chrome-canary',
       forward: {
         'http://github.com': `http://localhost:${APP_PORT}`,
         'http://google.com': `http://localhost:${APP_PORT}`,
@@ -55,6 +56,7 @@ test.serial('ws - config', async (t) => {
   t.like(JSON.parse(ws.messages.pendingPush[0].data.toString()), {
     type: 'config.update',
     payload: {
+      browser: 'chrome-canary',
       forward: {
         'http://github.com': `http://localhost:${APP_PORT}`,
         'http://google.com': `http://localhost:${APP_PORT}`,
@@ -68,8 +70,10 @@ test.serial('ws - config', async (t) => {
   const res = await (await fetch('http://github.com', opts)).json();
   t.like(res, { path: '/' });
 
-  const res2 = await (await fetch('http://google.com/echo', opts)).json();
-  t.like(res2, { path: '/echo' });
+  // the dot '.' in the path below is intentional
+  // see https://github.com/ballercat/jambox/pull/47
+  const res2 = await (await fetch('http://google.com/.echo', opts)).json();
+  t.like(res2, { path: '/.echo' });
 });
 
 test.serial('auto mocks', async (t) => {

--- a/src/matchers/GlobMatcher.mjs
+++ b/src/matchers/GlobMatcher.mjs
@@ -4,7 +4,7 @@ import mockttp from 'mockttp';
 
 const checkGlobs = (url, globs) => {
   for (const glob of globs) {
-    if (!minimatch(url.pathname, glob)) {
+    if (!minimatch(url.pathname, glob, { dot: true })) {
       return false;
     }
   }


### PR DESCRIPTION
- match pathnames with dot('.') literals in them
- serialize and accept a `browser` option in config

Turns out that `minimatch` wont match any string containing a dot(`.`) character even when given a `'**'` wildcard blob. That's less than ideal default behavior for path matching in jambox. Also, config wasn't properly serializing the `browser` value post the refactor update.