### PR TITLE
Add cors support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0 - Add auto CORS support in forwarded requests
+
+- feat: add cors support in forwarded requests
+
 ## 0.2.1 - Remove disable web security flags
 
 - fix: `--disable-web-security` removed. This causes Chrome to omit the Origin

--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ module.exports = {
       ],
       // Match websockets (support for NextJS local dev)
       websocket: true,
+      // Enable automatic cors support
+      // Useful for local servers which do not implement OPTIONS handlers
+      // An object of custom OPTIONS respond Headers could be provided as well
+      // default: false
+      cors: true,
     },
   },
   stub: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jambox",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Tool for recording and playing back HTTP requests.",
   "bin": {
     "jam": "./jam.mjs",

--- a/src/__tests__/server.test.mjs
+++ b/src/__tests__/server.test.mjs
@@ -101,6 +101,16 @@ test.serial('cors support', async (t) => {
   // OPTIONS should 204 automatically
   let response = await fetch(`http://jambox.test.com/foobar`, opts);
   t.like(response, { status: 204, statusText: 'No Content' });
+
+  response = await fetch(`http://jambox.test.com/foobar`, {
+    ...opts,
+    method: 'GET',
+  });
+
+  t.like(Object.fromEntries(response.headers.entries()), {
+    // This is set by jambox automatically when cors is enabled
+    'access-control-allow-origin': '*',
+  });
 });
 
 test.serial('auto mocks', async (t) => {

--- a/src/__tests__/server.test.mjs
+++ b/src/__tests__/server.test.mjs
@@ -76,6 +76,33 @@ test.serial('ws - config', async (t) => {
   t.like(res2, { path: '/.echo' });
 });
 
+test.serial('cors support', async (t) => {
+  t.assert(t.context.server, `Server init error: ${t.context.error?.stack}`);
+
+  const { body: config } = await supertest(t.context.server).get('/api/config');
+
+  await supertest(t.context.server)
+    .post('/api/config')
+    .send({
+      forward: {
+        'http://jambox.test.com': {
+          target: `http://localhost:${APP_PORT}`,
+          paths: ['**/foobar'],
+          cors: true,
+        },
+      },
+    });
+
+  const opts = {
+    agent: new HttpsProxyAgent(config.proxy.http),
+    method: 'OPTIONS',
+  };
+
+  // OPTIONS should 204 automatically
+  let response = await fetch(`http://jambox.test.com/foobar`, opts);
+  t.like(response, { status: 204, statusText: 'No Content' });
+});
+
 test.serial('auto mocks', async (t) => {
   t.assert(t.context.server, `Server init error: ${t.context.error?.stack}`);
   const { body: config } = await supertest(t.context.server).get('/api/config');


### PR DESCRIPTION
Allow the user to enable cors & `OPTIONS` handling for forwarded urls.

This will capture any `OPTIONS` requests to a forwarded URL and always reply with a permissive 204. Users can override the response headers if they wish, but these will apply to all handled options requests.