### PR TITLE
Support an array for the `forward` setting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0 - Support a forward array in configuration
+
+- feat: support an array in the `forward` setting
+
 ## 0.3.0 - Add auto CORS support in forwarded requests
 
 - feat: add cors support in forwarded requests

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jambox",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Tool for recording and playing back HTTP requests.",
   "bin": {
     "jam": "./jam.mjs",

--- a/src/Jambox.mjs
+++ b/src/Jambox.mjs
@@ -120,16 +120,26 @@ export default class Jambox extends Emitter {
   }
 
   forward(setting) {
-    return Promise.all(
-      Object.entries(setting).map(async ([original, ...rest]) => {
+    let entries;
+    if (Array.isArray(setting)) {
+      entries = setting;
+    } else {
+      entries = Object.entries(setting).map(([original, ...rest]) => {
         const options =
           typeof rest[0] === 'object'
             ? rest[0]
             : {
                 target: rest[0],
               };
-
-        const originalURL = new URL(original);
+        return {
+          original,
+          ...options,
+        };
+      });
+    }
+    return Promise.all(
+      entries.map(async (options) => {
+        const originalURL = new URL(options.original);
         const targetURL = new URL(
           options.target,
           // If the first argument of new URL() is a path the second argument is

--- a/src/Jambox.mjs
+++ b/src/Jambox.mjs
@@ -124,7 +124,7 @@ export default class Jambox extends Emitter {
     if (Array.isArray(setting)) {
       entries = setting;
     } else {
-      entries = Object.entries(setting).map(([original, ...rest]) => {
+      entries = Object.entries(setting).map(([match, ...rest]) => {
         const options =
           typeof rest[0] === 'object'
             ? rest[0]
@@ -132,14 +132,14 @@ export default class Jambox extends Emitter {
                 target: rest[0],
               };
         return {
-          original,
+          match,
           ...options,
         };
       });
     }
     return Promise.all(
       entries.map(async (options) => {
-        const originalURL = new URL(options.original);
+        const originalURL = new URL(options.match);
         const targetURL = new URL(
           options.target,
           // If the first argument of new URL() is a path the second argument is

--- a/src/__tests__/server.test.mjs
+++ b/src/__tests__/server.test.mjs
@@ -113,6 +113,48 @@ test.serial('cors support', async (t) => {
   });
 });
 
+test.serial('forward array', async (t) => {
+  t.assert(t.context.server, `Server init error: ${t.context.error?.stack}`);
+
+  const { body: config } = await supertest(t.context.server).get('/api/config');
+
+  await supertest(t.context.server)
+    .post('/api/config')
+    .send({
+      forward: [
+        {
+          match: 'http://jambox.test.com',
+          target: `http://localhost:${APP_PORT}`,
+          paths: ['**', '!**/foobar'],
+        },
+        {
+          match: 'http://jambox.test.com',
+          target: `http://localhost:${APP_PORT}`,
+          paths: ['**/foobar'],
+          cors: true,
+        },
+      ],
+    });
+
+  const opts = {
+    agent: new HttpsProxyAgent(config.proxy.http),
+    method: 'OPTIONS',
+  };
+
+  // OPTIONS should 204 automatically
+  let response = await fetch(`http://jambox.test.com/foobar`, opts);
+  t.like(response, { status: 204, statusText: 'No Content' });
+
+  response = await fetch(`http://jambox.test.com/foobar`, {
+    ...opts,
+    method: 'GET',
+  });
+
+  t.like(Object.fromEntries(response.headers.entries()), {
+    // This is set by jambox automatically when cors is enabled
+    'access-control-allow-origin': '*',
+  });
+});
 test.serial('auto mocks', async (t) => {
   t.assert(t.context.server, `Server init error: ${t.context.error?.stack}`);
   const { body: config } = await supertest(t.context.server).get('/api/config');


### PR DESCRIPTION
Support an array for the `forward` config option so that requests to the same domain could be routed to different servers based on paths.