### PR TITLE
Auto update host header when forwarding.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1 - Automatically update host header
+
+- fix: auto update host header during forwarding
+
 ## 0.4.0 - Support a forward array in configuration
 
 - feat: support an array in the `forward` setting

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jambox",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Tool for recording and playing back HTTP requests.",
   "bin": {
     "jam": "./jam.mjs",

--- a/src/Jambox.mjs
+++ b/src/Jambox.mjs
@@ -149,13 +149,12 @@ export default class Jambox extends Emitter {
         );
         const useSSL =
           targetURL.port === '443' || targetURL.protocol === 'https:';
-        const changeHosts = originalURL.host !== targetURL.host;
 
         const httpOptions = {
           ignoreHostHttpsErrors: true,
           forwarding: {
             targetHost: `http${useSSL ? 's' : ''}://${targetURL.host}`,
-            updateHostHeader: changeHosts ? originalURL.host : false,
+            updateHostHeader: true,
           },
         };
 
@@ -193,9 +192,17 @@ export default class Jambox extends Emitter {
             .asPriority(101)
             .thenJson(204, {}, optionsHeaders);
         }
+        if (options.debug) {
+          httpOptions.beforeRequest = (req) => {
+            debug(`[${originalURL.host}] ${req.path} match`);
+            return req;
+          };
+        }
 
         const matchers = [
-          new GlobMatcher(originalURL, { paths: options.paths || ['**'] }),
+          new GlobMatcher(originalURL, {
+            paths: options.paths || ['**'],
+          }),
         ];
 
         await this.proxy.addRequestRule({


### PR DESCRIPTION
- Host header will auto-update
- `debug: true` can be set for forward option for extra logging.